### PR TITLE
Fix/2.0.2

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -4,7 +4,6 @@
 
 ``` powershell
 Install-Module Pester -Force -Scope AllUsers
-Import-Module Pester -Passthru
 ```
 
 ## Perform Tests with Code Coverage

--- a/brickBOX.psd1
+++ b/brickBOX.psd1
@@ -1,17 +1,17 @@
 @{
 
 RootModule = 'brickBOX.psm1'   # Script module or binary module file associated with this manifest.
-ModuleVersion = '2.0.1'         # Version number of this module.
+ModuleVersion = '2.0.2'         # Version number of this module.
 # CompatiblePSEditions = @()    # Supported PSEditions
 GUID = '9d038cf3-b469-4b78-a235-46488538ae7c'  # ID used to uniquely identify this module
 
 Author = 'Patrick Page Gehrig'
 CompanyName = 'pageBOX.ch'
-Copyright = '(c) 2024 Patrick Page Gehrig. All rights reserved.'
+Copyright = '(c) 2025 Patrick Page Gehrig. All rights reserved.'
 
 Description = 'A collection of powershell functions, put in a module to make scripting easier'
 
-PowerShellVersion = '5.1'       # Minimum version of the PowerShell engine required by this module
+PowerShellVersion = '7.0'       # Minimum version of the PowerShell engine required by this module
 # PowerShellHostName = 'ConsoleHost' # Name of the PowerShell host required by this module. $host.name
 # PowerShellHostVersion = ''    # Minimum version of the PowerShell host required by this module
 # DotNetFrameworkVersion = ''   # Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.

--- a/public/Network/Convert-IPCalc.ps1
+++ b/public/Network/Convert-IPCalc.ps1
@@ -30,14 +30,16 @@
     process {
         # Function to convert IP address string to binary: "1.2.3.4" => "00000001000000100000001100000100"
         function toBinary ($dottedDecimal) {
+            $binary = ""
             $dottedDecimal.split(".") | ForEach-Object { $binary += $([convert]::toString($_,2).padleft(8,"0")) }
             return $binary
         }
 
         # Function to convert binary IP address to dotted decimal string: "00000001000000100000001100000100" => "1.2.3.4"
         function toDottedDecimal ($binary) {
-            do { $dottedDecimal += ".$([string]$([convert]::toInt32($binary.substring($i,8),2)))"; $i+=8 } while ($i -le 24)
-            return $dottedDecimal.substring(1)
+            $dottedDecimal = @()
+            0..3 | ForEach-Object { $dottedDecimal += [string]$([convert]::toInt32($binary.substring($_ * 8, 8), 2)) }
+            return ($dottedDecimal -join ".")
         }
 
         # Function to convert CIDR format to binary: 24 => "11111111111111111111111100000000"

--- a/public/Network/Convert-IPCalc.ps1
+++ b/public/Network/Convert-IPCalc.ps1
@@ -30,16 +30,19 @@
     process {
         # Function to convert IP address string to binary: "1.2.3.4" => "00000001000000100000001100000100"
         function toBinary ($dottedDecimal) {
-            $binary = ""
-            $dottedDecimal.split(".") | ForEach-Object { $binary += $([convert]::toString($_,2).padleft(8,"0")) }
-            return $binary
+            return ($dottedDecimal -split "\." | ForEach-Object { [convert]::ToString($_,2).padleft(8,"0") }) -join ""
+        }
+
+        # Function to convert IP address to Int32: "1.2.3.4" => 16909060
+        function toInt32 ([IPAddress]$ip) {
+            $bytes = $ip.GetAddressBytes()
+            if ([BitConverter]::IsLittleEndian) { [Array]::Reverse($bytes)}
+            return [BitConverter]::ToUInt32($bytes, 0)
         }
 
         # Function to convert binary IP address to dotted decimal string: "00000001000000100000001100000100" => "1.2.3.4"
         function toDottedDecimal ($binary) {
-            $dottedDecimal = @()
-            0..3 | ForEach-Object { $dottedDecimal += [string]$([convert]::toInt32($binary.substring($_ * 8, 8), 2)) }
-            return ($dottedDecimal -join ".")
+            return (0..3 | ForEach-Object { [string]$([convert]::toInt32($binary.substring($_ * 8, 8), 2)) }) -join "."
         }
 
         # Function to convert CIDR format to binary: 24 => "11111111111111111111111100000000"
@@ -63,29 +66,32 @@
         }
 
 
-        # Check to see if the IP Address was entered in CIDR format.
-        if ($IPAddress -like "*/*") {
-            $CIDRIPAddress = $IPAddress
-            $IPAddress = $CIDRIPAddress.Split("/")[0]
-            $cidr = [convert]::ToInt32($CIDRIPAddress.Split("/")[1])
-            if ($cidr -in 1..32 ) {
-                $ipBinary = toBinary $IPAddress
-                Write-Verbose $ipBinary
-                $smBinary = CidrToBin($cidr)
-                Write-Verbose $smBinary
-                $Netmask = toDottedDecimal($smBinary)
-                $wildcardbinary = NetMasktoWildcard ($smBinary)
-            } else { throw "Subnet Mask is invalid!" }
-        } else { # Address was not entered in CIDR format.
-            if (!$Netmask) { throw 'Subnet Mask is missing!' }
-            $ipBinary = toBinary $IPAddress
-            if ($Netmask -eq "0.0.0.0") { throw "Subnet Mask is invalid!" }
-            else {
-                $smBinary = toBinary $Netmask
-                $wildcardbinary = NetMasktoWildcard ($smBinary)
-            }
+        # Check the IP Address format. 
+        if ($IPAddress -match '^(?<ip>([0-9]{1,3}\.){3}[0-9]{1,3})(/(?<cidr>[1-9]|[12][0-9]|3[012]))?$') { 
+            $IPAddress = $Matches['ip'] 
+        } else { 
+            throw 'The input of the IP Address is invalid!' 
+        }
+        $cidr = [convert]::ToInt32($Matches['cidr'])
+
+        # check if IP Address is valid.
+        $IPAddress.split(".") | ForEach-Object {
+            if ([int]$_ -lt 0 -or [int]$_ -gt 255) { throw "IP Address is invalid!" }
+        }
+        
+        # check, if the Netmask and CIDR are both set.
+        if ($Netmask -and $cidr -gt 0) { throw 'You can not set both Netmask and CIDR!' }
+        
+        # check if Netmask is valid.
+        $Netmask.split(".") | ForEach-Object {
+            if ([int]$_ -lt 0 -or [int]$_ -gt 255) { throw "Netmask is invalid!" }
         }
 
+
+        $ipBinary = toBinary $IPAddress
+        $smBinary = if ($Netmask) { toBinary $Netmask } else { CidrToBin($cidr) }
+        if (!$Netmask) { $Netmask = toDottedDecimal($smBinary) }
+        $wildcardbinary = NetMasktoWildcard ($smBinary)
         $netBits = $smBinary.indexOf("0") # First determine the location of the first zero in the subnet mask in binary (if any)
 
         # If there is a 0 found then the subnet mask is less than 32 (CIDR).
@@ -124,6 +130,7 @@
         # Output custom object with or without binary information.
         $Output = [PSCustomObject]@{
             Address = $IPAddress
+            Address32 = toInt32 ([IPAddress]$IPAddress)
             Netmask = $Netmask
             Wildcard = $wildcard
             Network = "$networkID/$cidr"

--- a/public/ScriptProcessing/ConvertTo-Markdown.ps1
+++ b/public/ScriptProcessing/ConvertTo-Markdown.ps1
@@ -49,6 +49,8 @@ Function ConvertTo-Markdown {
         }
     }
     End {
+        if ($null -eq $InputObject) { return '' } # Write-Error "InputObject is null"
+
         $header = @()
         ($InputObject[0].PSObject.Properties).Name | ForEach-Object {
             $header += $_.PadRight($maxColLenght[$_])

--- a/tests/brickBOX.Tests.ps1
+++ b/tests/brickBOX.Tests.ps1
@@ -111,8 +111,11 @@ Describe 'Test ScriptProcessing' {
             $md | Should -Contain '-: | ------------'
             $md | Should -Contain ' 1 | page        '
             $md | Should -Contain ' 2 |             '
-             $md | Should -Contain ' 3 |             '
+            $md | Should -Contain ' 3 |             '
             $md | Should -Contain ' 4 | Name NewLine'
+        }
+        It 'Should return empty string' {
+           $oMD | Where-Object Name -EQ 'DoesNotExist' | ConvertTo-Markdown | Should -Be ''
         }
     }
     Context 'ConvertTo-Base64' {

--- a/tests/brickBOX.Tests.ps1
+++ b/tests/brickBOX.Tests.ps1
@@ -218,55 +218,67 @@ Describe 'Test Network' {
     Context 'Convert-IPCalc' {
         It 'Simple calc' {
             $ip = Convert-IPCalc 10.10.100.5/24
-            $ip.Address     | Should -be '10.10.100.5'
-            $ip.Netmask     | Should -be '255.255.255.0'
-            $ip.Wildcard    | Should -be '0.0.0.255'
-            $ip.Network     | Should -be '10.10.100.0/24'
-            $ip.Broadcast   | Should -be '10.10.100.255'
-            $ip.HostMin     | Should -be '10.10.100.1'
-            $ip.HostMax     | Should -be '10.10.100.254'
-            $ip.'Hosts/Net' | Should -be '254'
+            $ip.Address         | Should -be '10.10.100.5'
+            $ip.Address32       | Should -be 168453125
+            $ip.Netmask         | Should -be '255.255.255.0'
+            $ip.Wildcard        | Should -be '0.0.0.255'
+            $ip.Network         | Should -be '10.10.100.0/24'
+            $ip.Broadcast       | Should -be '10.10.100.255'
+            $ip.HostMin         | Should -be '10.10.100.1'
+            $ip.HostMax         | Should -be '10.10.100.254'
+            $ip.'Hosts/Net'     | Should -be '254'
             $ip.AddressBinary   | Should -Be $null
         }
         It 'Simple calc with /32' {
-            $ip = Convert-IPCalc 10.10.100.5/32
-            $ip.Address     | Should -be '10.10.100.5'
-            $ip.Netmask     | Should -be '255.255.255.255'
-            $ip.Wildcard    | Should -be '0.0.0.0'
-            $ip.Network     | Should -be '10.10.100.5/32'
-            $ip.Broadcast   | Should -be '10.10.100.5'
-            $ip.HostMin     | Should -be '10.10.100.5'
-            $ip.HostMax     | Should -be '10.10.100.5'
-            $ip.'Hosts/Net' | Should -be '1'
-            $ip.AddressBinary   | Should -Be $null
+            $ip = Convert-IPCalc 255.10.100.5/32
+            $ip.Address         | Should -be '255.10.100.5'
+            $ip.Address32       | Should -be 4278871045
+            $ip.Netmask         | Should -be '255.255.255.255'
+            $ip.Wildcard        | Should -be '0.0.0.0'
+            $ip.Network         | Should -be '255.10.100.5/32'
+            $ip.Broadcast       | Should -be '255.10.100.5'
+            $ip.HostMin         | Should -be '255.10.100.5'
+            $ip.HostMax         | Should -be '255.10.100.5'
+            $ip.'Hosts/Net'     | Should -be '1'
+            $ip.AddressBinary   | Should -be $null
         }
         It 'Calc with IncludeBinaryOutput' {
             $ip = Convert-IPCalc 10.10.100.5/24 -IncludeBinaryOutput
-            $ip.AddressBinary   | Should -Be '00001010000010100110010000000101'
-            $ip.NetmaskBinary   | Should -Be '11111111111111111111111100000000'
-            $ip.WildcardBinary  | Should -Be '00000000000000000000000011111111'
-            $ip.NetworkBinary   | Should -Be '00001010000010100110010000000000'
-            $ip.HostMinBinary   | Should -Be '00001010000010100110010000000001'
-            $ip.HostMaxBinary   | Should -Be '00001010000010100110010011111110'
-            $ip.BroadcastBinary | Should -Be '00001010000010100110010011111111'
+            $ip.AddressBinary   | Should -be '00001010000010100110010000000101'
+            $ip.NetmaskBinary   | Should -be '11111111111111111111111100000000'
+            $ip.WildcardBinary  | Should -be '00000000000000000000000011111111'
+            $ip.NetworkBinary   | Should -be '00001010000010100110010000000000'
+            $ip.HostMinBinary   | Should -be '00001010000010100110010000000001'
+            $ip.HostMaxBinary   | Should -be '00001010000010100110010011111110'
+            $ip.BroadcastBinary | Should -be '00001010000010100110010011111111'
         }
         It 'Calc with IncludeHostList' {
             $ip = Convert-IPCalc 10.10.100.5/26 -IncludeHostList
             $ip.'Hosts/Net' -eq $ip.HostList.Count | Should -BeTrue
-            $ip.HostList[2] | Should -be '10.10.100.3'
+            $ip.HostList[2]     | Should -be '10.10.100.3'
+            $ip.HostList[-1]    | Should -be '10.10.100.62'
         }
-        It 'Test Subnet Mask' {
-            { Convert-IPCalc 10.10.100.5 } | Should -Throw
-            { Convert-IPCalc 10.10.100.5/33 } | Should -Throw
-            { Convert-IPCalc 10.10.100.5/abc } | Should -Throw
-            { Convert-IPCalc 10.10.100.5/-10 } | Should -Throw
-            { Convert-IPCalc 10.10.100.5 -Netmask '0.0.0.0' } | Should -Throw
+        It 'Test Subnet Mask & CIDR validation' {
+            { Convert-IPCalc 10.10.100.5 }      | Should -Throw
+            { Convert-IPCalc 10.10.100.5/24 -Netmask '255.255.255.0' } | Should -Throw
+            { Convert-IPCalc 10.10.100.5/33 }   | Should -Throw
+            { Convert-IPCalc 10.10.100.5/abc }  | Should -Throw
+            { Convert-IPCalc 10.10.100.5/-10 }  | Should -Throw
+            { Convert-IPCalc 10.10.100.5 -Netmask '0.0.0.0' }   | Should -Throw
             { Convert-IPCalc 10.10.100.5 -Netmask '257.0.0.0' } | Should -Throw
-            #{ Convert-IPCalc 10.10.100.5 -Netmask 'abc.0.0.0' } | Should -Throw
+            { Convert-IPCalc 10.10.100.5 -Netmask '-55.0.0.0' } | Should -Throw
+            { Convert-IPCalc 10.10.100.5 -Netmask '255.255.0' } | Should -Throw
+            { Convert-IPCalc 10.10.100.5 -Netmask '255.0.0.0.0' } | Should -Throw
+            { Convert-IPCalc 10.10.100.5 -Netmask '255.0.255.0' } | Should -Throw
+            { Convert-IPCalc 10.10.100.5 -Netmask 'abc.0.0.0' } | Should -Throw
         }
         It 'Test IP Address' {
-            { Convert-IPCalc 257.10.100.5/24 } | Should -Throw
-            { Convert-IPCalc 257.10.100.5/32 } | Should -Throw
+            { Convert-IPCalc 257.1.1.5/24 } | Should -Throw
+            { Convert-IPCalc -57.1.1.5/24 } | Should -Throw
+            { Convert-IPCalc abc.1.1.5/24 } | Should -Throw
+            { Convert-IPCalc 1.1.1.1.1/24 } | Should -Throw
+            { Convert-IPCalc 10.10.10/24 }  | Should -Throw
+            { Convert-IPCalc 257.1.1.5/32 } | Should -Throw
         }
     }
 }


### PR DESCRIPTION
- bug in Convert-IPCalc fixed (not initialized var)
- added Address32 to Convert-IPCalc
- lots of code-cleanup for Convert-IPCalc
- minimal PowerShellVersion is now 7.0
- a lot of tests added for Convert-IPCalc
- bugfix in ConvertTo-Markdown for $null handle exception